### PR TITLE
Update dataProcessing.js

### DIFF
--- a/src/main/resources/public/js/workflow/dataProcessing.js
+++ b/src/main/resources/public/js/workflow/dataProcessing.js
@@ -712,7 +712,7 @@ $(function () {
         stop: function () {
             var result = $("#select-result").empty();
             variablesArr = new Array();
-            $(".ui-selected", this).each(function () {
+            $("li.ui-selected", this).each(function () {
                 var currSel = $(this).attr("value");
                 tmpArr = currSel.split('~');
                 variablesArr.push({'idVar': tmpArr[0], 'name': tmpArr[1], 'labelTab': tmpArr[2], 'prefixTab': tmpArr[3]});


### PR DESCRIPTION
It fix the bug on dialog box to select variable into roles.
The problem is that the jquery selector $("ui-selected", this) returns not only the "li" objects but also some children object and tmpArr = currSel.split('~'); will return undefined and bug for these children.